### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/instacapture/src/main/java/com/tarek360/instacapture/utility/Utility.java
+++ b/instacapture/src/main/java/com/tarek360/instacapture/utility/Utility.java
@@ -11,9 +11,13 @@ import java.util.Locale;
 /**
  * Created by tarek on 5/18/16.
  */
-public class Utility {
+public final class Utility {
 
   private static final String SCREENSHOTS_DIRECTORY_NAME = "screenshots";
+
+  private Utility() throws InstantiationException {
+    throw new InstantiationException("This utility class is not created for instantiation");
+  }
 
   public static File getScreenshotFile(@NonNull final Context applicationContext) {
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - Utility classes should not have public constructors

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1118

Please let me know if you have any questions.

M-Ezzat
