### PR TITLE
Removed RTL and allowBackup on the manifest

### DIFF
--- a/instacapture/src/main/AndroidManifest.xml
+++ b/instacapture/src/main/AndroidManifest.xml
@@ -1,11 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.tarek360.instacapture">
 
-  <application android:allowBackup="true"
-      android:label="@string/app_name"
-      android:supportsRtl="true"
-  >
-
-  </application>
+  <application />
 
 </manifest>


### PR DESCRIPTION
A library should not specify this.

When trying this library, I got an error message:
```
app/src/main/AndroidManifest.xml:46:7-34 Error:
	Attribute application@allowBackup value=(false) from AndroidManifest.xml:46:7-34
	is also present at [com.github.tarek360:instacapture:2.0.1] AndroidManifest.xml:12:9-35 value=(true).
	Suggestion: add 'tools:replace="android:allowBackup"' to <application> element at AndroidManifest.xml:44:5-157:19 to override.
app/src/main/AndroidManifest.xml:50:7-34 Error:
	Attribute application@supportsRtl value=(false) from AndroidManifest.xml:50:7-34
	is also present at [com.github.tarek360:instacapture:2.0.1] AndroidManifest.xml:14:9-35 value=(true).
	Suggestion: add 'tools:replace="android:supportsRtl"' to <application> element at AndroidManifest.xml:44:5-157:19 to override.
```